### PR TITLE
Support for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
 	"require": {
 		"consistence/consistence-jms-serializer": "~1.0",
 		"jms/serializer-bundle": "~1.0|~2.0",
-		"symfony/config": "~3.0",
-		"symfony/dependency-injection": "~3.0",
-		"symfony/http-kernel": "~3.0",
-		"symfony/yaml": "~3.0"
+		"symfony/config": "~3.4|~4.0",
+		"symfony/dependency-injection": "~3.4|~4.0",
+		"symfony/http-kernel": "~3.4|~4.0",
+		"symfony/yaml": "~3.4|~4.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "2.4",

--- a/readme.md
+++ b/readme.md
@@ -314,14 +314,11 @@ composer require consistence/consistence-jms-serializer-symfony
 2) Register the bundle in your application kernel:
 
 ```php
-// app/AppKernel.php
-public function registerBundles()
-{
-	return [
-		// ...
-		new Consistence\JmsSerializer\SymfonyBundle\ConsistenceJmsSerializerBundle(),
-	];
-}
+// config/bundles.php
+return [
+	// ...
+	Consistence\JmsSerializer\SymfonyBundle\ConsistenceJmsSerializerBundle::class => ['all' => true],
+];
 ```
 
 That's all, you are good to go!


### PR DESCRIPTION
For release in 1.x, because new serializer can be blocked by other dependencies.